### PR TITLE
Remove unused serial printer support

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -7,9 +7,6 @@ var client = new Client('irc.freenode.net', 'sudobot', {
 });
 var minimist = require('minimist');
 
-var SerialPort = require('serialport').SerialPort
-var serial = new SerialPort('/dev/ttyS0', { baud: 9600 })
-
 var split = require('split2');
 var through = require('through2');
 var spawn = require('child_process').spawn;
@@ -71,9 +68,6 @@ client.addListener('message#sudoroom', function (from, message) {
 
         var ps = spawn('aoss', ['flite', '-voice', '/opt/voices/cmu_us_slt.flitevox']);
         ps.stdin.end(argv._.join(' '));
-    } else if (/^!print\s+/.test(message) && serial.isOpen()) {
-        var txt = message.replace(/^print\s+/, '')
-        serial.write(txt + '\r\n')
     }
     if (/sudoroom_BigTV/.test(message)) {
       spawn('ssh', ['pi@100.64.64.27', 'bin/mainscreenturnon']);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "irc": "^0.3.12",
     "minimist": "^1.1.1",
-    "serialport": "^2.0.5",
     "split2": "^0.2.1",
     "through2": "^0.6.5"
   },


### PR DESCRIPTION
We don't have a serial printer attached to the system where the bot runs, and the code doesn't react well if there's no `/dev/ttyS0`, so rather than fix the code I'd rather we just remove it for now.